### PR TITLE
fix: 0.0.1-alpha feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ kong_group: "{{ kong_user }}"
 ```
 
 ```yaml
+kong_conf_dest: /etc/kong/kong.conf
+```
+
+```yaml
 kong_log_dir: /var/log/kong
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ kong_dest_deb: /tmp/kong.deb
 kong_user: kong
 kong_group: "{{ kong_user }}"
 
+kong_conf_dest: /etc/kong/kong.conf
+
 kong_log_dir: /var/log/kong
 
 kong_conf_general_prefix: /usr/local/kong/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,7 @@ kong_conf_datastore_pg_password: kong
 kong_conf_datastore_pg_database: kong
 kong_conf_datastore_pg_ssl: off
 kong_conf_datastore_pg_ssl_verify: off
-kong_conf_datastore_cassandra_contact_point: 127.0.0.1
+kong_conf_datastore_cassandra_contact_points: 127.0.0.1
 kong_conf_datastore_cassandra_port: 9042
 kong_conf_datastore_cassandra_keyspace: kong
 kong_conf_datastore_cassandra_consistency: ONE

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,8 +30,8 @@
   template:
     src: etc/kong/kong.conf.j2
     dest: "{{ kong_conf_dest }}"
-    notify:
-      - reload kong
+  notify:
+    - reload kong
 
 - name: Ensure log service directory exists
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: "{{ item }}"
     state: installed
-    with_items: "{{ kong_apt_dependencies }}"
+  with_items: "{{ kong_apt_dependencies }}"
 
 - name: Download kong deb package
   get_url:

--- a/templates/etc/kong/kong.conf.j2
+++ b/templates/etc/kong/kong.conf.j2
@@ -53,7 +53,7 @@ pg_ssl_verify = {{ kong_conf_datastore_pg_ssl_verify }} # if pg_ssl = on
 
 cassandra_contact_points = {{ kong_conf_datastore_cassandra_contact_points }}
 cassandra_port = {{ kong_conf_datastore_cassandra_port }}
-cassandra_keyspace = {{ kong_conf_datastore_keyspace }}
+cassandra_keyspace = {{ kong_conf_datastore_cassandra_keyspace }}
 cassandra_consistency = {{ kong_conf_datastore_cassandra_consistency }}
 cassandra_timeout = {{ kong_conf_datastore_cassandra_timeout }}
 cassandra_ssl = {{ kong_conf_datastore_cassandra_ssl }}


### PR DESCRIPTION
- `with_items` indentation error
- missing default `kong_conf_dest `
- typo in default ~~`kong_conf_datastore_cassandra_contact_point`~~ => `kong_conf_datastore_cassandra_contact_points`
- typo in template var ~~`kong_conf_datastore_keyspace`~~ => `kong_conf_datastore_cassandra_keyspace`
- `notify` indentation fail